### PR TITLE
Added popoverClickable

### DIFF
--- a/src/Yesod/Bootstrap.hs
+++ b/src/Yesod/Bootstrap.hs
@@ -530,6 +530,43 @@ $().ready(function(){
 });
 |]
 
+popoverClickable :: WidgetT site IO () -> WidgetT site IO () -> WidgetT site IO () -> WidgetT site IO ()
+popoverClickable title popup inner = do
+  containerId <- newIdent
+  innerId <- newIdent
+  popupWrapId <- newIdent
+  titleWrapId <- newIdent
+  span_ [("id",containerId)] $ do
+    a_ [("href","javascript://"),("id",innerId)] inner
+    div_ [("id",popupWrapId),("style","display:none;")] $ do
+      popup
+    div_ [("id",titleWrapId),("style","display:none;")] $ do
+      title
+  toWidget [julius|
+$().ready(function(){
+  $('##{rawJS innerId}').popover(
+    { html: true
+    , trigger: 'manual'
+    , content: function() { return $('##{rawJS popupWrapId}').html(); }
+    , title: function() { return $('##{rawJS titleWrapId}').html(); }
+    }
+  );
+  var hidePopover#{rawJS innerId} = function () {
+    $('##{rawJS innerId}').popover('hide');
+    $(document).off("click keypress", hidePopover#{rawJS innerId} );
+  };
+  $('##{rawJS innerId}').focusin(function() {
+      $('##{rawJS innerId}').popover('show');
+    });
+  $('##{rawJS innerId}').on("shown.bs.popover", function() {
+      $('##{rawJS containerId}').find(".popover").on("click keypress", function(e) {
+          e.stopPropagation();
+        });
+      $(document).on("click keypress", hidePopover#{rawJS innerId});
+    });
+});
+|]
+
 trueThenFalse :: [Bool]
 trueThenFalse = True : repeat False
 


### PR DESCRIPTION
I've added a popover that let's you interact with the popover contents without closing it. 

If you're want to know the technical details of it, It basically stops click and keypress events from propagating outside the popover, but closes the popover if there is a click or keypress anywhere else on the page. It also only has a handler listening for page clicks and keypresses when the popover is open, and removes the handler when the popover closes, so the performance will be good with lots of popovers on a page.

I'll make a note of the only bug I've encountered. If you follow this process:
1. click button to open popover
2. click same button to close popover
3. click button again to reopen popover

You'll have an problem where, on the 3rd step, the popover won't reopen. You have to click somewhere else on the page between the 2nd and 3rd step to allow it to reopen. This seems like a minor issue right now. 
